### PR TITLE
fix gverify_version bug in failure yaml

### DIFF
--- a/eugl/gqa/geometric_utils.py
+++ b/eugl/gqa/geometric_utils.py
@@ -55,7 +55,7 @@ def _write_gqa_yaml(out_fname, data):
         yaml.safe_dump(data, f, default_flow_style=False, indent=4)
 
 def _write_failure_yaml(out_fname, granule, msg, ref_source=None,
-                        ref_source_path=None, ref_date=None):
+                        ref_source_path=None, ref_date=None, gverify_version=None):
     """
     We'll cater for future tasks by passing through reference image details,
     if we decide to write a yaml for when a gverify execution fails
@@ -73,6 +73,7 @@ def _write_failure_yaml(out_fname, granule, msg, ref_source=None,
     data['ref_date'] = ref_date
     data['final_gcp_count'] = 0
     data['residual'] = _populate_nan_residuals()
+    data['gverify_version'] = gverify_version
     _write_gqa_yaml(out_fname, data)
 
 

--- a/eugl/gqa/tasks.py
+++ b/eugl/gqa/tasks.py
@@ -174,8 +174,9 @@ class GQATask(luigi.Task):
             parse_gqa(self, temp_yaml, references, band_id, sat_id, temp_directory)
 
         except (ValueError, FileNotFoundError, CommandError) as ve:
-            # failed because GQA cannot be calculated
-            _write_failure_yaml(temp_yaml, self.granule, str(ve))
+            _LOG.debug('failed because GQA cannot be calculated: %s', str(ve))
+            _write_failure_yaml(temp_yaml, self.granule, str(ve),
+                                gverify_version=self.gverify_binary.split('_')[-1])
             with open(pjoin(temp_directory, 'gverify.log'), 'w') as src:
                 src.write('gverify was not executed because:\n')
                 src.write(str(ve))


### PR DESCRIPTION
- Fix for the failure caused by `gverify_version` not being in the failure `.yaml` for GQA.