### PR TITLE
address non-terminating gverify

### DIFF
--- a/eugl/fmask.py
+++ b/eugl/fmask.py
@@ -38,7 +38,7 @@ class CommandError(RuntimeError):
     pass
 
 
-def run_command(command, work_dir):
+def run_command(command, work_dir, timeout=None):
     """
     A simple utility to execute a subprocess command.
     Raises a CalledProcessError for backwards compatibility
@@ -50,13 +50,24 @@ def run_command(command, work_dir):
         shell=True,
         cwd=str(work_dir)
     )
-    _proc.wait()
+
+    timed_out = False
+
+    try:
+        _proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _proc.kill()
+        timed_out = True
 
     stdout, stderr = _proc.communicate()
     if _proc.returncode != 0:
         _LOG.error(stderr.decode('utf-8'))
         _LOG.info(stdout.decode('utf-8'))
-        raise CommandError('"%s" failed with return code: %s' % (command, str(_proc.returncode)))
+
+        if timed_out:
+            raise CommandError('"%s" timed out' % (command))
+        else:
+            raise CommandError('"%s" failed with return code: %s' % (command, str(_proc.returncode)))
     else:
         _LOG.debug(stdout.decode('utf-8'))
 

--- a/eugl/gqa/tasks.py
+++ b/eugl/gqa/tasks.py
@@ -110,6 +110,7 @@ class GQATask(luigi.Task):
     gverify_root_fix_qa_location = luigi.Parameter()
     gverify_iterations = luigi.Parameter()
     gverify_standard_deviations = luigi.Parameter()
+    gverify_timeout = luigi.Parameter()
 
     def requires(self):
         return [DataStandardisation(self.level1, self.workdir, self.granule)]
@@ -159,7 +160,7 @@ class GQATask(luigi.Task):
                 extra = ['-g', self.gverify_grid_size]
                 cmd = gverify_cmd(self, vrt_file, source_band, temp_directory, extra=extra)
                 _LOG.debug('calling gverify %s', ' '.join(cmd))
-                run_command(cmd, temp_directory)
+                run_command(cmd, temp_directory, timeout=int(self.gverify_timeout))
             else:
                 # create a set of fix-points from landsat path-row
                 points_txt = pjoin(temp_directory, 'points.txt')
@@ -168,7 +169,7 @@ class GQATask(luigi.Task):
                 extra = ['-t', 'FIXED_LOCATION', '-t_file', points_txt]
                 cmd = gverify_cmd(self, vrt_file, source_band, temp_directory, extra=extra)
                 _LOG.debug('calling gverify %s', ' '.join(cmd))
-                run_command(cmd, temp_directory)
+                run_command(cmd, temp_directory, timeout=int(self.gverify_timeout))
 
             _LOG.debug('finished gverify on %s', self.granule)
             parse_gqa(self, temp_yaml, references, band_id, sat_id, temp_directory)

--- a/eugl/gqa/tasks.py
+++ b/eugl/gqa/tasks.py
@@ -110,7 +110,7 @@ class GQATask(luigi.Task):
     gverify_root_fix_qa_location = luigi.Parameter()
     gverify_iterations = luigi.Parameter()
     gverify_standard_deviations = luigi.Parameter()
-    gverify_timeout = luigi.Parameter()
+    gverify_timeout = luigi.IntParameter(default=300)
 
     def requires(self):
         return [DataStandardisation(self.level1, self.workdir, self.granule)]
@@ -160,7 +160,7 @@ class GQATask(luigi.Task):
                 extra = ['-g', self.gverify_grid_size]
                 cmd = gverify_cmd(self, vrt_file, source_band, temp_directory, extra=extra)
                 _LOG.debug('calling gverify %s', ' '.join(cmd))
-                run_command(cmd, temp_directory, timeout=int(self.gverify_timeout))
+                run_command(cmd, temp_directory, timeout=self.gverify_timeout)
             else:
                 # create a set of fix-points from landsat path-row
                 points_txt = pjoin(temp_directory, 'points.txt')
@@ -169,7 +169,7 @@ class GQATask(luigi.Task):
                 extra = ['-t', 'FIXED_LOCATION', '-t_file', points_txt]
                 cmd = gverify_cmd(self, vrt_file, source_band, temp_directory, extra=extra)
                 _LOG.debug('calling gverify %s', ' '.join(cmd))
-                run_command(cmd, temp_directory, timeout=int(self.gverify_timeout))
+                run_command(cmd, temp_directory, timeout=self.gverify_timeout)
 
             _LOG.debug('finished gverify on %s', self.granule)
             parse_gqa(self, temp_yaml, references, band_id, sat_id, temp_directory)


### PR DESCRIPTION
For some Sentinel-2 granules, the actual data captured does not cover enough area for gverify to successfully run. Instead of giving up though, gverify keeps trying indefinitely.

- Set a timeout (currently 300 seconds as specified in the luigi config) for the gverify call