### PR TITLE
Update fmask rios source

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={'eugl.gqa': ['data/*.csv']},
     dependency_links=[
         'git+https://github.com/ubarsc/rios@rios-1.4.10#egg=rios-1.4.10',
-        'git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.4#egg=pythonfmask-0.5.4',
+        'git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.4#egg=python-fmask-0.5.4',
         'git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     ],
     package_data={'eugl.gqa': ['data/*.csv']},
     dependency_links=[
-        'hg+https://bitbucket.org/chchrsc/rios/get/rios-1.4.8.zip#egg=rios-1.4.8',
-        'hg+https://bitbucket.org/chchrsc/python-fmask/get/python-fmask-0.5.4.zip#egg=python-fmask-0.5.4'
+        'git+https://github.com/ubarsc/rios@rios-1.4.10#egg=rios-1.4.10',
+        'git+https://github.com/ubarsc/python-fmask@pythonfmask-5.4.0#egg=pythonfmask-5.4.0',
         'git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={'eugl.gqa': ['data/*.csv']},
     dependency_links=[
         'git+https://github.com/ubarsc/rios@rios-1.4.10#egg=rios-1.4.10',
-        'git+https://github.com/ubarsc/python-fmask@pythonfmask-5.4.0#egg=pythonfmask-5.4.0',
+        'git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.4#egg=pythonfmask-0.5.4',
         'git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl',
     ]
 )


### PR DESCRIPTION
The RIOS and python-fmaks packages have been migrated from bitbucket to GitHub.  This PR will updates the dependency links to point to the new location.