### PR TITLE
Minor fixes; bump fmask version to install; resolve module conflict

### DIFF
--- a/eugl/__init__.py
+++ b/eugl/__init__.py
@@ -1,10 +1,10 @@
 try:
-    from importlib import metadata
+    from importlib import metadata as _md
 except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
-    import importlib_metadata as metadata
+    import importlib_metadata as _md
 
 try:
-    __version__ = metadata.version(__name__)
-except metadata.PackageNotFoundError:
+    __version__ = _md.version(__name__)
+except _md.PackageNotFoundError:
     __version__ = "Not Installed"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy",
         "rasterio",
         "rios",
-        "python-fmask",
+        "python-fmask==0.5.5",
         "wagl",
         "importlib-metadata;python_version<'3.8'",
     ],
@@ -26,7 +26,7 @@ setup(
     package_data={"eugl.gqa": ["data/*.csv"]},
     dependency_links=[
         "git+https://github.com/ubarsc/rios@rios-1.4.10#egg=rios-1.4.10",
-        "git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.4#egg=python-fmask-0.5.4",  # noqa: E501
+        "git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.5#egg=python-fmask-0.5.5",  # noqa: E501
         "git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl",
     ],
 )


### PR DESCRIPTION
A very minor fix to resolve a library conflict when loading metadata from importlib (which occurs in eugl.__init__), and metadata from eugl.

Also update version of fmask to install. python-fmask has updated metadata and page references.