### PR TITLE
Use gdal cli to apply offset values to S2 data

### DIFF
--- a/eugl/fmask.py
+++ b/eugl/fmask.py
@@ -339,7 +339,7 @@ def _sentinel2_fmask(
     cmd = [
         "fmask_sentinel2Stacked.py",
         "-a",
-        update_vrt_fname,
+        vrt_fname,
         "-z",
         angles_fname,
         "-o",
@@ -347,7 +347,7 @@ def _sentinel2_fmask(
         "--cloudbufferdistance",
         str(cloud_buffer_distance),
         "--shadowbufferdistance",
-        str(cloud_buffer_distance)
+        str(cloud_shadow_buffer_distance)
     ]
 
     if parallax_test:

--- a/eugl/fmask.py
+++ b/eugl/fmask.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from wagl.acquisition import acquisitions
 from wagl.constants import BandType
 
-from eugl.metadata import fmask_metadata
+from eugl.metadata import fmask_metadata, grab_offset_dict
 
 _LOG = logging.getLogger(__name__)
 
@@ -230,24 +230,124 @@ def _sentinel2_fmask(
     """
     Fmask algorithm for Sentinel-2.
     """
-    cmd = ["unzip", dataset_path, "-d", work_dir]
+    # temp_vrt_fname: save vrt with offest values in metadata
+    temp_vrt_fname = pjoin(work_dir, "reflective.tmp.vrt")
+    # vrt_fname: save vrt with applied offest values by gdal_translate
+    vrt_fname = pjoin(work_dir, "reflective.vrt")
+    angles_fname = pjoin(work_dir, ".angles.img")
+
+    acqs = []
+    for grp in container.groups:
+        acqs.extend(container.get_acquisitions(grp, granule, False))
+
+    band_ids = [acq.band_id for acq in acqs]
+    required_ids = [str(i) for i in range(1, 13)]
+    required_ids.insert(8, "8A")
+
+    acq = container.get_acquisitions(granule=granule)[0]
+
+    # zipfile extraction
+    xml_out_fname = pjoin(work_dir, Path(acq.granule_xml).name)
+    if ".zip" in acq.uri:
+        cmd = ["unzip", "-p", dataset_path, acq.granule_xml, ">", xml_out_fname]
+        run_command(cmd, work_dir)
+
+    offsets = grab_offset_dict(dataset_path)
+
+    # vrt creation
+    cmd = [
+        "gdalbuildvrt",
+        "-resolution",
+        "user",
+        "-tr",
+        "20",
+        "20",
+        "-separate",
+        "-overwrite",
+        temp_vrt_fname,
+    ]
+
+    # when we use band to create VRT, also pass its offset values
+    # to offset_values list, which will be used in gdal_edit later
+    offset_values = []
+
+    for band_id in required_ids:
+
+        acq = acqs[band_ids.index(band_id)]
+
+        # if we process data before 2021-Nov, we will have an emtry
+        # offset_dict because there is no offset values in metadata.xml.
+        # ideally, we should create a default offset_dict
+        # with same keys but all values are 0, but S2 band_ids
+        # is hard to use a simple loop to create.
+        if band_id in offsets:
+            offset_values.append(offsets[band_id])
+        else:
+            offset_values.append(0)
+
+        if ".zip" in acq.uri:
+
+            jp2_path = acq.uri.replace("zip:", "/vsizip/").replace("!", "")
+            cmd.append(jp2_path)
+
+        else:
+            cmd.append(acq.uri)
+
     run_command(cmd, work_dir)
 
-    safe_dir = str(list(Path(work_dir).iterdir())[0])
+    # use this CLI to attach offset values to VRT as metadata info
+    cmd = [
+            "gdal_edit.py",
+            "-ro",
+            "-offset",
+            ' '.join([str(e) for e in offset_values]),
+            temp_vrt_fname
+        ]
+
+    run_command(cmd, work_dir)
+
+    # use this CLI to apply offset metadata for the bands
+    cmd = [
+            "gdal_translate",
+            temp_vrt_fname,
+            vrt_fname,
+            "-unscale"
+        ]
+
+    run_command(cmd, work_dir)
+
+    # angles generation
+    if ".zip" in acq.uri:
+        cmd = [
+            "fmask_sentinel2makeAnglesImage.py",
+            "-i",
+            xml_out_fname,
+            "-o",
+            angles_fname,
+        ]
+    else:
+        cmd = [
+            "fmask_sentinel2makeAnglesImage.py",
+            "-i",
+            acq.granule_xml,
+            "-o",
+            angles_fname,
+        ]
+    run_command(cmd, work_dir)
 
     # run fmask
     cmd = [
         "fmask_sentinel2Stacked.py",
-        "--safedir",
-        safe_dir,
-        "--tempdir",
-        work_dir,
+        "-a",
+        update_vrt_fname,
+        "-z",
+        angles_fname,
         "-o",
         out_fname,
         "--cloudbufferdistance",
         str(cloud_buffer_distance),
         "--shadowbufferdistance",
-        str(cloud_shadow_buffer_distance),
+        str(cloud_buffer_distance)
     ]
 
     if parallax_test:

--- a/eugl/fmask.py
+++ b/eugl/fmask.py
@@ -347,7 +347,7 @@ def _sentinel2_fmask(
         "--cloudbufferdistance",
         str(cloud_buffer_distance),
         "--shadowbufferdistance",
-        str(cloud_shadow_buffer_distance)
+        str(cloud_shadow_buffer_distance),
     ]
 
     if parallax_test:

--- a/eugl/metadata.py
+++ b/eugl/metadata.py
@@ -135,3 +135,38 @@ def fmask_metadata(
 
     with open(out_fname, "w") as src:
         yaml.safe_dump(md, src, default_flow_style=False, indent=4)
+
+
+def grab_offset_dict(dataset_path):
+    """grab_offset_dict: get the offset values from zipped XML metadata file
+
+    :param dataset_path: S2 dataset (zip file path)
+    :returns metadata dictionary: {band_id: offset_value}
+    """
+
+    archive = zipfile.ZipFile(dataset_path)
+    xml_root = xml_via_safe(archive, dataset_path)
+
+    # ESA image ids
+    esa_ids = [
+        "B01",
+        "B02",
+        "B03",
+        "B04",
+        "B05",
+        "B06",
+        "B07",
+        "B08",
+        "B8A",
+        "B09",
+        "B10",
+        "B11",
+        "B12",
+        "TCI",
+    ]
+
+    # ESA L1C upgrade introducing scaling/offset
+    search_term = './*/Product_Image_Characteristics/Radiometric_Offset_List/RADIO_ADD_OFFSET'
+
+    return {re.sub(r'B[0]?', '', esa_ids[int(x.attrib['band_id'])]): int(x.text)
+               for x in xml_root.findall(search_term)}


### PR DESCRIPTION
Hi, How are you.

In this PR:

1. add a new method `grab_offset_dict` in metadata.py to extract offset values from zipped XML file (normally copy paste from [wagl] (https://github.com/GeoscienceAustralia/wagl/blob/develop/wagl/acquisition/__init__.py#L697) design).
2. modify the `_sentinel2_fmask` moethod. Compare to [pre 2021-Nov version](https://github.com/OpenDataCubePipelines/eugl/blob/8b717a8626ff2b1c5db808a7fb3d5715589fd117/eugl/fmask.py#L220-L312). I added three steps in CLI:
- use `grab_offset_dict` method to grab offset_dict (band_id -> offset_value).
- use `gdal_edit` CLI to attach offset values to VRT metadata
- use `gdal_translate` CLI to apply offest values to VRT

This S2 fix have to run with Python-FMask 5.5.

Cheers

Sai