### PR TITLE
Change FMask version back to 0.5.5 in our pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy",
         "rasterio",
         "rios",
-        "python-fmask==0.5.7",
+        "python-fmask==0.5.5",
         "wagl",
         "importlib-metadata;python_version<'3.8'",
     ],
@@ -26,7 +26,7 @@ setup(
     package_data={"eugl.gqa": ["data/*.csv"]},
     dependency_links=[
         "git+https://github.com/ubarsc/rios@rios-1.4.10#egg=rios-1.4.10",
-        "git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.7#egg=python-fmask-0.5.7",  # noqa: E501
+        "git+https://github.com/ubarsc/python-fmask@pythonfmask-0.5.5#egg=python-fmask-0.5.5",  # noqa: E501
         "git+https://github.com/GeoscienceAustralia/wagl@develop#egg=wagl",
     ],
 )


### PR DESCRIPTION
Hello,

How are you.

The [gdal_edit solution](https://github.com/OpenDataCubePipelines/eugl/pull/51) can only works with FMask 0.5.5 interfaces because FMask 0.5.7 only accept SAFE folder as input. So we have to change Python-FMask back to its old version in our pipeline environment.

Cheers

Sai