### PR TITLE
More minor lint stabilisation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.271
+  rev: v0.0.278
   hooks:
     - id: ruff
       args: [ --fix, --exit-non-zero-on-fix ]
 -   repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 23.7.0
     hooks:
     -   id: black
         language_version: python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ requires-python = ">=3.6"
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 
 [tool.ruff]
+
+target-version = "py38"
+
 line-length = 90
 # Which checkers to enable?
 select = [


### PR DESCRIPTION
Specify a target python version to avoid noise between different versions.

(and more importantly, minimise CI failures on old builds)